### PR TITLE
Use new stable repo URL for `stable/` prefix

### DIFF
--- a/pkg/devspace/helm/generic/generic.go
+++ b/pkg/devspace/helm/generic/generic.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const stableChartRepo = "https://kubernetes-charts.storage.googleapis.com"
+const stableChartRepo = "https://charts.helm.sh/stable"
 
 type VersionedClient interface {
 	IsValidHelm(path string) (bool, error)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #1446


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
no

**Does this pull request add new dependencies?**  
no

**What else do we need to know?**  
Helm changed the URL for their stable and incubator charts last year. The old URLs were deprecated in November.
https://helm.sh/blog/new-location-stable-incubator-charts/